### PR TITLE
aggiunti file per nodi villas

### DIFF
--- a/Villas/Dockerfile_node_a
+++ b/Villas/Dockerfile_node_a
@@ -1,0 +1,7 @@
+FROM registry.git.rwth-aachen.de/acs/public/villas/node
+
+WORKDIR /configs
+
+ENTRYPOINT [ "sh" ]
+
+CMD ["-c","villas signal -f json -F 50 -r 1600 -a 1.414 sine | villas pipe -f json ./node.conf nodo_lab_a"]

--- a/Villas/Dockerfile_node_b
+++ b/Villas/Dockerfile_node_b
@@ -1,0 +1,7 @@
+FROM registry.git.rwth-aachen.de/acs/public/villas/node
+
+WORKDIR /configs
+
+ENTRYPOINT [ "sh" ]
+
+CMD ["-c","villas-node ./path.conf"]

--- a/Villas/node.conf
+++ b/Villas/node.conf
@@ -22,7 +22,7 @@ nodes = {
             type = "villas.human"
 
             comment_prefix = "#"
-            header = false
+            header = true
         },
 
         in = {
@@ -63,7 +63,7 @@ nodes = {
             type = "villas.human"
 
             comment_prefix = "#"
-            header = false
+            header = true
         },
 
         in = {

--- a/Villas/node.conf
+++ b/Villas/node.conf
@@ -1,0 +1,81 @@
+# Nodi per un test di collegamento
+
+hugepages = 100
+stats = 1
+affinity = 0x3
+#priority = 99
+uuid="b98aeac0-fef1-428f-b0e1-314350d4f4a5"
+
+# Nodi per un test di collegamento
+nodes = {
+	nodo_lab_a = {
+        type = "socket",
+        layer = "udp",
+        vectorize = 30,             # Receive and sent 30 samples per message (combining).
+        builtin = false,            # By default, all nodes will have a few builtin hooks attached to them.
+                                    # When collecting statistics or measurements these are undesired.
+        
+        format = {
+            type = "opal.asyncip"
+        },
+
+        in = {
+            address = "*:12000", # FROM LAB A
+            signals = (
+                    #{  name = "I", unit = "Ampere", type = "complex" }
+                    { signals = "30i", name = "I", unit = "Ampere", type = "float"}
+            ),
+            hooks = (
+                {
+                    type = "stats",
+                    enabled = true,
+                    verbose = true,
+                    output = "stats_from_cassino_node.log",
+                    format = "json"
+                }
+            )
+        },
+        out = {
+            address = "192.168.1.66:12000",   # TO LAB B
+            signals = (
+                    #{  name = "I", unit = "Ampere", type = "complex"}
+                    { signals = "30i", name = "I", unit = "Ampere", type = "float"}
+            )
+        }
+    },
+    nodo_lab_b = {
+        type = "socket",
+        layer = "udp",
+        vectorize = 30,             # Receive and sent 30 samples per message (combining).
+        builtin = false,            # By default, all nodes will have a few builtin hooks attached to them.
+                                    # When collecting statistics or measurements these are undesired.
+        
+        format = {
+            type = "opal.asyncip"
+        },
+
+        in = {
+            address = "*:12001", # FROM LAB B
+            signals = (
+                    #{  name = "V", unit = "Volt", type = "complex"}
+                    { signals = "30i", name = "V", unit = "Volt", type = "float"}
+            ),
+            hooks = (
+                {
+                    type = "stats",
+                    enabled = true,
+                    verbose = true,
+                    output = "stats_from_cassino_node.log",
+                    format = "json"
+                }
+            )
+        },
+        out = {
+            address = "127.0.0.1:12002",   # TO LAB A
+            signals = (
+                    #{  name = "V", unit = "Volt", type = "complex"}
+                    { signals = "30i", name = "V", unit = "Volt", type = "float"}
+            )
+        }
+    }
+}

--- a/Villas/node.conf
+++ b/Villas/node.conf
@@ -15,8 +15,14 @@ nodes = {
         builtin = false,            # By default, all nodes will have a few builtin hooks attached to them.
                                     # When collecting statistics or measurements these are undesired.
         
+        #format = {
+        #    type = "opal.asyncip"
+        #},
         format = {
-            type = "opal.asyncip"
+            type = "villas.human"
+
+            comment_prefix = "#"
+            header = false
         },
 
         in = {
@@ -50,8 +56,14 @@ nodes = {
         builtin = false,            # By default, all nodes will have a few builtin hooks attached to them.
                                     # When collecting statistics or measurements these are undesired.
         
+        #format = {
+        #    type = "opal.asyncip"
+        #},
         format = {
-            type = "opal.asyncip"
+            type = "villas.human"
+
+            comment_prefix = "#"
+            header = false
         },
 
         in = {

--- a/Villas/path.conf
+++ b/Villas/path.conf
@@ -12,17 +12,22 @@ paths = (
         hooks = ( { 
             type = "print",
 			enabled = true,
-			format = {
-                        type = "json"
-                        indent = 0
-                        compact = true
-                        ts_received = true
-                        ts_origin = true
-                        offset = false
-                        real_precision = 3
-                        sequence = true
-                    }
-			})
+            format = {
+                type = "villas.human"
+                comment_prefix = "#"
+                header = false
+            }
+			#format = {
+            #            type = "json"
+            #            indent = 0
+            #            compact = true
+            #            ts_received = true
+            #            ts_origin = true
+            #            offset = false
+            #            real_precision = 3
+            #            sequence = true
+            #        }
+			}),
 	},
     {
 		in  = [ "nodo_lab_b" ], 
@@ -33,16 +38,21 @@ paths = (
         hooks = ({
             type = "print",
 			enabled = true,
-			format = {
-                        type = "json"
-                        indent = 0
-                        compact = true
-                        ts_received = true
-                        ts_origin = true
-                        offset = false
-                        real_precision = 3
-                        sequence = true
-                    }
+            format = {
+                type = "villas.human"
+                comment_prefix = "#"
+                header = false
+            }
+			#format = {
+            #            type = "json"
+            #            indent = 0
+            #            compact = true
+            #            ts_received = true
+            #            ts_origin = true
+            #            offset = false
+            #            real_precision = 3
+            #            sequence = true
+            #        }
 			})
 	}
 )

--- a/Villas/path.conf
+++ b/Villas/path.conf
@@ -15,7 +15,7 @@ paths = (
             format = {
                 type = "villas.human"
                 comment_prefix = "#"
-                header = false
+                header = true
             }
 			#format = {
             #            type = "json"
@@ -41,7 +41,7 @@ paths = (
             format = {
                 type = "villas.human"
                 comment_prefix = "#"
-                header = false
+                header = true
             }
 			#format = {
             #            type = "json"

--- a/Villas/path.conf
+++ b/Villas/path.conf
@@ -1,0 +1,48 @@
+# File di configurazione per Daemon su nodo villas UNIVERSITA VANVITELLI 
+
+@include "node.conf"
+
+paths = (
+	{
+		in  = [ "nodo_lab_a" ], 
+        out = [ "nodo_lab_b" ],
+        reverse = false,
+        enabled = true,
+        original_sequence_no = true,
+        hooks = ( { 
+            type = "print",
+			enabled = true,
+			format = {
+                        type = "json"
+                        indent = 0
+                        compact = true
+                        ts_received = true
+                        ts_origin = true
+                        offset = false
+                        real_precision = 3
+                        sequence = true
+                    }
+			})
+	},
+    {
+		in  = [ "nodo_lab_b" ], 
+        out = [ "nodo_lab_a" ], 
+	    reverse = false,
+        enabled = true,
+        original_sequence_no = true,
+        hooks = ({
+            type = "print",
+			enabled = true,
+			format = {
+                        type = "json"
+                        indent = 0
+                        compact = true
+                        ts_received = true
+                        ts_origin = true
+                        offset = false
+                        real_precision = 3
+                        sequence = true
+                    }
+			})
+	}
+)

--- a/Villas/run_example_command
+++ b/Villas/run_example_command
@@ -1,0 +1,17 @@
+#docker run --name test_container --cap-add=NET_ADMIN --privileged --tty --interactive --entrypoint /bin/bash --volume /Users/giovannibarbato/progetti/rt_sim_distibuted_framework:/configs -p 13007:13007/udp -p 13008:13008/udp villas_node:1.0
+#docker run --name villas_node -it --rm --network=host --privileged --tty --interactive --entrypoint bash --volume /Users/giovannibarbato/progetti/rt_sim_distibuted_framework:/configs -p 13007:13007/udp -p 13008:13008/udp registry.git.rwth-aachen.de/acs/public/villas/node
+#docker run --name villas_node -it --rm --network=host --privileged --tty --interactive --entrypoint bash --volume /Users/giovannibarbato/progetti/rt_sim_distibuted_framework:/configs villas:1.0
+
+docker run --name villas_node_test --rm -p 12000:12000/udp test_villas_node:1.0
+
+docker run --name villas_node_test --rm -p 12000:12000/udp --volume /Users/giovannibarbato/progetti/rt_sim_distibuted_framework:/configs test_villas_node:1.0
+
+docker run --cpuset-cpus="0-1" \
+  --ulimit rtprio=99 \
+  --cap-add=sys_nice \
+  --security-opt seccomp=unconfined \
+  --privileged \
+  --name villas_node_test -it \
+  --rm \
+  --volume /home/realtime/rt_sim_distibuted_framework:/configs \
+  -p 12000:12000/udp test_villas_node:1.0

--- a/Villas/run_node_a.sh
+++ b/Villas/run_node_a.sh
@@ -1,0 +1,8 @@
+docker rm -f villas_node_test
+
+docker rmi test_villas_node:1.0
+
+sudo docker build -t test_villas_node:1.0 -f Dockerfile_node_a .
+
+docker run --name villas_node_test --rm -p 12000:12000/udp --volume $(pwd):/configs test_villas_node:1.0
+

--- a/Villas/run_node_b.sh
+++ b/Villas/run_node_b.sh
@@ -1,0 +1,15 @@
+docker rm -f villas_node_test
+
+docker rmi test_villas_node:1.0
+
+sudo docker build -t test_villas_node:1.0 -f Dockerfile_node_b .
+
+docker run --cpuset-cpus="0-1" \
+  --ulimit rtprio=99 \
+  --cap-add=sys_nice \
+  --security-opt seccomp=unconfined \
+  --privileged \
+  --name villas_node_test -it \
+  --rm \
+  --volume $(pwd):/configs \
+  -p 12000:12000/udp test_villas_node:1.0


### PR DESCRIPTION
nel file sh run_node_b trovi la sequanza per avviare un nodo villas che usa come file di configurazione il path.conf e node.conf ascoltando sulla porta 12000 UDP